### PR TITLE
Fix: 카카오 소셜 로그인 인증 체계 개선

### DIFF
--- a/src/main/java/flowfit/domain/oauth2/application/service/impl/CreateAccessTokenAndRefreshTokenServiceImpl.java
+++ b/src/main/java/flowfit/domain/oauth2/application/service/impl/CreateAccessTokenAndRefreshTokenServiceImpl.java
@@ -7,6 +7,7 @@ import flowfit.global.jwt.domain.repository.JsonWebTokenRepository;
 import flowfit.global.jwt.util.JWTUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -14,6 +15,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class CreateAccessTokenAndRefreshTokenServiceImpl implements CreateAccessTokenAndRefreshTokenService {
 
     private final JWTUtil jwtUtil;

--- a/src/main/java/flowfit/domain/oauth2/application/service/impl/KakaoLoginServiceImpl.java
+++ b/src/main/java/flowfit/domain/oauth2/application/service/impl/KakaoLoginServiceImpl.java
@@ -43,6 +43,8 @@ public class KakaoLoginServiceImpl implements KakaoLoginService {
         Role role = Role.valueOf(values.get("role"));
         String userEmail = values.get("email");
 
+        log.info(oAuth2TokenResponse.accessToken());
+        log.info(oAuth2TokenResponse.refreshToken());
         // Kakao 토큰 저장
         KakaoJsonWebToken KakaoToken = KakaoJsonWebToken.builder()
                 .userId(userId)

--- a/src/main/java/flowfit/domain/oauth2/application/service/impl/KakaoUserCreateServiceImpl.java
+++ b/src/main/java/flowfit/domain/oauth2/application/service/impl/KakaoUserCreateServiceImpl.java
@@ -5,6 +5,8 @@ import flowfit.domain.oauth2.presentation.dto.response.OAuth2TokenResponse;
 import flowfit.domain.oauth2.presentation.dto.response.OAuth2UserResponse;
 import flowfit.domain.user.domain.entity.Role;
 import flowfit.domain.user.domain.entity.User;
+import flowfit.domain.user.domain.entity.trainer.Trainer;
+import flowfit.domain.user.domain.repository.TrainerRepository;
 import flowfit.domain.user.domain.repository.UserRepository;
 import flowfit.global.jwt.domain.entity.KakaoJsonWebToken;
 import flowfit.global.jwt.domain.repository.KakaoJsonWebTokenRepository;
@@ -24,26 +26,39 @@ public class KakaoUserCreateServiceImpl implements KakaoUserCreateService {
 
     private final UserRepository userRepository;
     private final KakaoJsonWebTokenRepository KakaoJsonWebTokenRepository;
+    private final TrainerRepository trainerRepository;
 
     @Override
     public Map<String, String> createKakaoUser(OAuth2TokenResponse oAuth2TokenResponse, OAuth2UserResponse oAuth2UserResponse) {
+        log.info("사용자 생성 시작: oAuth2UserResponse.id()={}", oAuth2UserResponse.id());
+
+        // null 체크 추가
+        if (oAuth2UserResponse.id() == null || oAuth2UserResponse.id().isEmpty()) {
+            log.error("카카오에서 반환된 사용자 ID가 null 또는 빈 문자열입니다");
+            throw new IllegalArgumentException("사용자 ID가 유효하지 않습니다");
+        }
+
         User user = userRepository.findById(oAuth2UserResponse.id()).orElse(null);
 
         if(user == null) {
-            log.info("신규 고객님, {} 님이 입장하셨습니다.", oAuth2UserResponse.name());
+            log.info("신규 고객님, {} 님이 입장하셨습니다.", oAuth2UserResponse.getName());
+            log.info("신규 고객님, {} 님이 입장하셨습니다.", oAuth2UserResponse.getEmail());
+            log.info("신규 고객님, {} 님이 입장하셨습니다.", oAuth2UserResponse.getProfile());
             user = User.builder()
                     .id(oAuth2UserResponse.id())
-                    .email(oAuth2UserResponse.email())
-                    .name(oAuth2UserResponse.name())
-                    .profile(oAuth2UserResponse.profile())
+                    .email(oAuth2UserResponse.getEmail())  // 메소드 호출 방식으로 변경
+                    .name(oAuth2UserResponse.getName())    // 메소드 호출 방식으로 변경
+                    .profile(oAuth2UserResponse.getProfile())  // 메소드 호출 방식으로 변경
                     .role(Role.TRAINER)
                     .build();
+            userRepository.save(user);
+            trainerRepository.save(new Trainer(user));
         }
         else {
-            user.updateNameAndEmailAndProfile(oAuth2UserResponse.name(), oAuth2UserResponse.email(), oAuth2UserResponse.profile());
+            user.updateNameAndEmailAndProfile(oAuth2UserResponse.getName(), oAuth2UserResponse.getEmail(), oAuth2UserResponse.getProfile());
         }
 
-        userRepository.save(user);
+
 
         LocalDateTime now = LocalDateTime.now().plusSeconds(oAuth2TokenResponse.expiresIn());
 

--- a/src/main/java/flowfit/domain/oauth2/application/service/impl/KakaoUserServiceImpl.java
+++ b/src/main/java/flowfit/domain/oauth2/application/service/impl/KakaoUserServiceImpl.java
@@ -4,9 +4,11 @@ import flowfit.domain.oauth2.application.service.KakaoUserService;
 import flowfit.domain.oauth2.presentation.dto.response.OAuth2UserResponse;
 import flowfit.global.infra.feignclient.KakaoOAuth2UserFeignClient;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class KakaoUserServiceImpl implements KakaoUserService {
 
@@ -14,6 +16,8 @@ public class KakaoUserServiceImpl implements KakaoUserService {
 
     @Override
     public OAuth2UserResponse getUser(String accessToken) {
-        return KakaoOAuth2UserFeignClient.getUserInfo("Bearer " + accessToken);
+        OAuth2UserResponse response = KakaoOAuth2UserFeignClient.getUserInfo("Bearer " + accessToken);
+        log.info("카카오 API 응답: {}", response);
+        return response;
     }
 }

--- a/src/main/java/flowfit/domain/oauth2/infra/filter/FlowfitJWTFilter.java
+++ b/src/main/java/flowfit/domain/oauth2/infra/filter/FlowfitJWTFilter.java
@@ -36,6 +36,7 @@ public class FlowfitJWTFilter extends OncePerRequestFilter {
         String requestURI = request.getRequestURI();
 
         if(requestURI.contains("/api/oauth2/login") || requestURI.contains("/api/oauth2/callback")) {
+            log.info("안녕?");
             String accessToken = jwtUtil.getAccessTokenFromHeaders(request);
             if(jwtUtil.jwtVerify(accessToken, "access")) {
                 throw new DuplicateLoginException();

--- a/src/main/java/flowfit/domain/oauth2/presentation/controller/KakaoLoginController.java
+++ b/src/main/java/flowfit/domain/oauth2/presentation/controller/KakaoLoginController.java
@@ -3,22 +3,24 @@ package flowfit.domain.oauth2.presentation.controller;
 import flowfit.domain.oauth2.application.service.KakaoLoginService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/oauth2")
 @RequiredArgsConstructor
+@Slf4j
 public class KakaoLoginController {
 
     private final KakaoLoginService KakaoLoginService;
 
-    @PostMapping("/callback")
+    @GetMapping("/callback")
     public void login(@RequestParam("code") String code, HttpServletResponse response) throws IOException {
         KakaoLoginService.login(code, response);
+        log.info("응답 Authorization 헤더: {}", response.getHeader(HttpHeaders.AUTHORIZATION));
+        log.info("응답 Set-Cookie 헤더: {}", response.getHeader(HttpHeaders.SET_COOKIE));
     }
 }

--- a/src/main/java/flowfit/domain/oauth2/presentation/dto/response/OAuth2UserResponse.java
+++ b/src/main/java/flowfit/domain/oauth2/presentation/dto/response/OAuth2UserResponse.java
@@ -2,17 +2,41 @@ package flowfit.domain.oauth2.presentation.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+// 수정된 OAuth2UserResponse 클래스
 public record OAuth2UserResponse(
-        @JsonProperty("sub")
+        @JsonProperty("id")
         String id,
 
-        @JsonProperty("name")
-        String name,
-
-        @JsonProperty("email")
-        String email,
-
-        @JsonProperty("picture")
-        String profile
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount
 ) {
+        public String getName() {
+                return kakaoAccount != null && kakaoAccount.profile != null
+                        ? kakaoAccount.profile.nickname : null;
+        }
+
+        public String getEmail() {
+                return kakaoAccount != null ? kakaoAccount.email : null;
+        }
+
+        public String getProfile() {
+                return kakaoAccount != null && kakaoAccount.profile != null
+                        ? kakaoAccount.profile.profileImageUrl : null;
+        }
+
+        public record KakaoAccount(
+                @JsonProperty("profile")
+                Profile profile,
+
+                @JsonProperty("email")
+                String email
+        ) {}
+
+        public record Profile(
+                @JsonProperty("nickname")
+                String nickname,
+
+                @JsonProperty("profile_image_url")
+                String profileImageUrl
+        ) {}
 }

--- a/src/main/java/flowfit/domain/user/domain/entity/User.java
+++ b/src/main/java/flowfit/domain/user/domain/entity/User.java
@@ -26,20 +26,20 @@ public class User {
     private String email;
 
     //아이디
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String username;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String password;
 
     // 이름
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String profile;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String phoneNumber;
 
     @CreationTimestamp

--- a/src/main/java/flowfit/global/config/SecurityConfig.java
+++ b/src/main/java/flowfit/global/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
     private final ObjectMapper objectMapper;
     private final JsonWebTokenRepository jsonWebTokenRepository;
     private final KakaoJsonWebTokenRepository KakaoJsonWebTokenRepository;
-    private final List<String> excludedUrls = Arrays.asList("/api/reissue", "/api/oauth2/login", "/api/users/join", "/api/users/login", "/api/healthcheck", "/api/oauth2/callback");
+    private final List<String> excludedUrls = Arrays.asList("/favicon.ico","/api/reissue", "/api/oauth2/login", "/api/users/join", "/api/users/login", "/api/healthcheck", "/api/oauth2/callback");
 
 
     @Bean
@@ -69,6 +69,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/oauth2/callback").permitAll()
                         .requestMatchers("/api/users/join").permitAll()
                         .requestMatchers("/api/users/login").permitAll()
+                        .requestMatchers("/favicon.ico").permitAll()
                         .requestMatchers("/api/reissue").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement((session) -> session

--- a/src/main/java/flowfit/global/infra/presentation/controller/AuthenticationCheckController.java
+++ b/src/main/java/flowfit/global/infra/presentation/controller/AuthenticationCheckController.java
@@ -1,15 +1,22 @@
 package flowfit.global.infra.presentation.controller;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
+@Slf4j
 public class AuthenticationCheckController {
     @GetMapping("/authcheck")
     @ResponseStatus(HttpStatus.OK)
     public void authcheck() {}
+
+    @PostMapping("/test")
+    public ResponseEntity<String> test(@AuthenticationPrincipal String userId) {
+        log.info(userId);
+        return ResponseEntity.ok("힝");
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5

## 📝작업 내용

- 소셜 로그인 성공(refresh+access 토큰 Redis에 저장 및 회원정보 테이블에 저장)
- 하지만... 포스트맨에서 토큰이 기본 저장이 되지 않아서 테스트 불가... 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?